### PR TITLE
Fix filemanager not launch

### DIFF
--- a/res/xml/command_list.xml
+++ b/res/xml/command_list.xml
@@ -41,7 +41,7 @@
 
   <!-- Console info -->
   <command commandId="groups" commandPath="/system/xbin/groups" commandArgs="" />
-  <command commandId="id" commandPath="/system/bin/id" commandArgs="-Gn" />
+  <command commandId="id" commandPath="/system/bin/id" commandArgs="" />
 
   <!-- FileSystem -->
   <command commandId="mount" commandPath="/system/bin/mount" commandArgs="-o %1$s,remount -t %2$s %3$s" />


### PR DESCRIPTION
M is using toybox instead of toolbox, some commands in filemanager
relies on toolbox utilities, there are minor difference in handling.
This change removes the "-Gn" argument pass to id command for retrival
the uid/gid, tested on both M and L, there is no need to add -Gn argument,
but in L, it seems -Gn is ignored. In M it will output wihtout the numerical
values causing parsing exception during startup.

Change-Id: I6aac8e94a80671df0a247ffcaf7d69364d7c9ad2